### PR TITLE
Fix syntax for Americano decaf option

### DIFF
--- a/index.html
+++ b/index.html
@@ -162,7 +162,7 @@ const COFFEE_CAFFEINE_MG = {
 
   moka4: 160,   // Moka pot (for 4 people, estimate per person)
   americano: 150, // Americano
-  americano decaf: 50, // Americano decaffeinato
+  'americano decaf': 50, // Americano decaffeinato
 
   decaf: 15      // Decaffeinated coffee
 };


### PR DESCRIPTION
## Summary
- fix invalid key for "americano decaf" in caffeine map

## Testing
- `node - <<'NODE'
const COFFEE_CAFFEINE_MG = {
  single: 80,
  doppio: 120,
  moka4: 160,
  americano: 150,
  'americano decaf': 50,
  decaf: 15
};
console.log(COFFEE_CAFFEINE_MG);
NODE`

------
https://chatgpt.com/codex/tasks/task_e_6878b3382c44832082eb01998deecf6c